### PR TITLE
fix: LangGraph agent tool usage and miscellaneous fixes

### DIFF
--- a/app/tools/rag_knowledge.py
+++ b/app/tools/rag_knowledge.py
@@ -4,11 +4,11 @@ import os
 from typing import List
 
 from langchain_community.document_loaders import TextLoader
-from langchain_community.vectorstores import Qdrant
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.runnables.passthrough import RunnablePassthrough
 from langchain_core.tools import BaseTool, tool
 from langchain_openai import OpenAIEmbeddings
+from langchain_qdrant import QdrantVectorStore
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 from qdrant_client import QdrantClient
 from qdrant_client.http.models import Distance, VectorParams
@@ -73,10 +73,10 @@ class NASCARKnowledgeRAG:
         )
 
         # Create vector store
-        self.vectorstore = Qdrant(
+        self.vectorstore = QdrantVectorStore(
             client=client,
             collection_name="nascar_knowledge",
-            embeddings=self.embeddings,
+            embedding=self.embeddings,
         )
 
         # Add documents

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -1,8 +1,17 @@
 """TrackHouse MCP Server - Integrated with edge_server/web_server."""
 
 import argparse
+import os
 import sys
 from pathlib import Path
+
+# Suppress FastMCP banner and verbose output
+os.environ["FASTMCP_DISABLE_BANNER"] = "1"
+os.environ["FASTMCP_QUIET"] = "1"
+
+# Suppress FastMCP logging when used in stdio mode
+import logging
+logging.getLogger("fastmcp").setLevel(logging.ERROR)
 
 from fastmcp import FastMCP
 
@@ -282,8 +291,10 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    # Print server info
-    print_server_info(transport=args.transport, host=args.host, port=args.port)
+    # Only print server info when running standalone (not when called from agents)
+    # Check if we're being run directly vs imported
+    if sys.stdin.isatty():  # Running in terminal
+        print_server_info(transport=args.transport, host=args.host, port=args.port)
 
     if args.transport == "http":
         mcp.run(transport="http", host=args.host, port=args.port)

--- a/mcp_server/tools/utils.py
+++ b/mcp_server/tools/utils.py
@@ -7,7 +7,7 @@ import httpx
 from pydantic import BaseModel
 
 # Configuration
-WEB_SERVER_URL = os.getenv("WEB_SERVER_URL", "http://localhost:5000")
+WEB_SERVER_URL = os.getenv("WEB_SERVER_URL", "http://localhost:8000")
 API_TIMEOUT = 30
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "requests>=2.32.0",
     "fastmcp>=2.11.3",
+    "langchain-qdrant>=0.2.0",
 ]
 
 [project.optional-dependencies]

--- a/run_pitbox.py
+++ b/run_pitbox.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+"""CLI runner for the NASCAR Pit Box Agent."""
+
+import asyncio
+import sys
+from langchain_core.messages import HumanMessage, AIMessage
+from app.graphs.simple_pitbox import graph
+
+
+async def main():
+    """Run the simple pitbox agent with a question from command line."""
+    
+    # Get the question from command line arguments or use default
+    if len(sys.argv) > 1:
+        question = " ".join(sys.argv[1:])
+    else:
+        print("Usage: python run_pitbox.py <your question>")
+        print("Example: python run_pitbox.py What is NASCAR?")
+        print("\nUsing default question: What is NASCAR?")
+        question = "What is NASCAR?"
+    
+    print(f"\n🏁 NASCAR Pit Box Agent")
+    print("=" * 60)
+    print(f"Question: {question}")
+    print("=" * 60)
+    print("\nThinking...\n")
+    
+    try:
+        # Invoke the graph with the user's question (async)
+        result = await graph.ainvoke({
+            "messages": [HumanMessage(content=question)]
+        })
+        
+        # Get the final message (should be the AI's response)
+        final_message = result["messages"][-1]
+        
+        # Print the response
+        if isinstance(final_message, AIMessage):
+            print("Answer:")
+            print("-" * 60)
+            print(final_message.content)
+        else:
+            print("Unexpected response type:", type(final_message))
+            print(final_message)
+            
+    except Exception as e:
+        print(f"Error: {e}")
+        print("\nMake sure:")
+        print("1. You have set OPENAI_API_KEY environment variable")
+        print("2. The mock edge server is running: uv run python mock_edge_server.py")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/uv.lock
+++ b/uv.lock
@@ -940,6 +940,20 @@ wheels = [
 ]
 
 [[package]]
+name = "langchain-qdrant"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "pydantic" },
+    { name = "qdrant-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/8c/f006636b4cc2d95ba072a57df3f2f99d8cf7cb47a79cc447a7e3e391f7ee/langchain_qdrant-0.2.0.tar.gz", hash = "sha256:41b8573cbb1b4706f76dc769251d8e6b3e4107ecd5fa97c58141977ec19fba75", size = 21429, upload-time = "2024-11-05T20:51:15.122Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/01/22dad84373ba282237a3351547443c9c94c39fe75f71a1759f97cfa89725/langchain_qdrant-0.2.0-py3-none-any.whl", hash = "sha256:8eab5b8a553204ddb809d8183a6f1bc12fc265688592d9d897388f6939c79bf8", size = 23406, upload-time = "2024-11-05T20:51:13.472Z" },
+]
+
+[[package]]
 name = "langchain-text-splitters"
 version = "0.3.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1570,6 +1584,7 @@ dependencies = [
     { name = "langchain-community" },
     { name = "langchain-mcp-adapters" },
     { name = "langchain-openai" },
+    { name = "langchain-qdrant" },
     { name = "langchain-text-splitters" },
     { name = "langgraph" },
     { name = "python-dotenv" },
@@ -1601,6 +1616,7 @@ requires-dist = [
     { name = "langchain-community", specifier = ">=0.3.0" },
     { name = "langchain-mcp-adapters", specifier = ">=0.1.0" },
     { name = "langchain-openai", specifier = ">=0.2.0" },
+    { name = "langchain-qdrant", specifier = ">=0.2.0" },
     { name = "langchain-text-splitters", specifier = ">=0.3.0" },
     { name = "langgraph", specifier = ">=0.2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },


### PR DESCRIPTION
## Description

This PR addresses several key issues to improve the LangGraph agent's functionality:

- **Fixed server port configuration**: Corrected Trackhouse web server port from 5000 to 8000.
- **Added async tool execution support**: Created a new function to handle tool execution in the LangGraph agent. Previously, the agent failed to call tools because it was designed only for synchronous operations, while MCP tools require async handling. This update modifies the tool calling function to support asynchronous execution.
- **Added test script**: Included a new Python file for testing the implementation. To use it, run `uv run python run_pitbox.py <question>` (ensure the web server is running first).
- **Silenced verbose logging**: Disabled FastMCP logs and startup banner to reduce console noise.